### PR TITLE
Add Docker Configuration

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,7 +4,7 @@ FROM golang:1.22.3
 WORKDIR /app
 
 # Copy go mod and sum files
-COPY go.mod go.sum ./
+COPY go.mod ./
 
 # Download all dependencies
 RUN go mod download

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,13 @@
+FROM golang:1.22.3
+
+# Set working directory
+WORKDIR /app
+
+# Copy go mod and sum files
+COPY go.mod go.sum ./
+
+# Download all dependencies
+RUN go mod download
+
+# Expose port 8000
+EXPOSE 8080

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+dev/start:
+	docker-compose -f compose.dev.yml up -d 
+
+dev/stop:
+	docker-compose -f compose.dev.yml down --rmi all

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -1,0 +1,13 @@
+
+services:
+
+  backend:
+    container_name: exp_009_2024__backend
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    tty: true
+    ports: 
+      - 8080:8080
+    volumes:
+      - .:/app


### PR DESCRIPTION
This should solve issue #4

- Go version has been set to `golang:1.22.3`, with plans to upgrade to `golang:1.23` in the near future to explore the new language iterators support.
- Backend service is configured to run on port `:8080`, which is the default port for Go projects.
- We decided to name Docker-Compose file as `compose.dev.yml` instead of `docker-compose.dev.yml` for brevity.
- We should add `go.sum` file in Dockerfile in the future after installing some Go package.